### PR TITLE
refractor: replace rest api with GQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
           "description": "Docs language, en-US or zh-CN, please restart vscode after change this setting"
         },
         "AntdDocs.githubToken": {
-          "type" : "string",
+          "type": "string",
           "default": "",
           "description": "This plugin uses github restful API to fetch docs, which has a rate limit of 60 times per hour. If you have a github token, you can set it here to increase the rate limit."
         }
@@ -84,6 +84,7 @@
   "dependencies": {
     "@babel/parser": "^7.22.5",
     "@babel/traverse": "^7.22.5",
+    "@octokit/graphql": "^7.0.2",
     "@octokit/rest": "^19.0.11",
     "remark-gfm": "^3.0.1",
     "remark-parse": "^10.0.2",

--- a/src/fetchDocs.ts
+++ b/src/fetchDocs.ts
@@ -2,6 +2,47 @@ import { Octokit } from '@octokit/rest';
 import { ANTD_GITHUB, excludeDirs } from './constant';
 import { DocsLang, DocsMap } from './types';
 import * as vscode from 'vscode';
+import { graphql } from '@octokit/graphql';
+
+const splitText = '____';
+
+const recoverText = (text: string) => text.replaceAll(splitText, '-');
+
+const getComponentsDocText = async (componentNames: string[], token: string, ref: string) => {
+  const queries = componentNames?.map(componentName => createQuery(componentName, ref));
+  const { repository } = await graphql<{ repository: Record<string, null | { text: string }> }>(
+    `
+query{
+  repository(owner: "${ANTD_GITHUB.OWNER}", name: "${ANTD_GITHUB.REPO}") {
+    ${queries.join('\n')}
+  }
+}
+    `,
+    {
+      headers: {
+        authorization: `token ${token}`,
+      },
+    }
+  );
+  return repository;
+};
+
+const createQuery = (componentName: string, ref: string) => {
+  const zhName = `${componentName.replaceAll('-', splitText)}zh`;
+  const enName = `${componentName.replaceAll('-', splitText)}en`;
+  return `
+      ${zhName}: object(expression: "${ref}:components/${componentName}/${ANTD_GITHUB.ZH_DOC_NAME}") {
+        ... on Blob {
+          text
+        }
+      }
+      ${enName}: object(expression: "${ref}:components/${componentName}/${ANTD_GITHUB.EN_DOC_NAME}") {
+        ... on Blob {
+          text
+        }
+      }
+  `;
+};
 
 const getAntdContent = (path: string, token: string, ref?: string) => new Octokit({ auth: token }).rest.repos.getContent({
   owner: ANTD_GITHUB.OWNER,
@@ -31,7 +72,7 @@ export const getFileContent = async (owner: string, repo: string, path: string, 
 
 export const getComponentDirInfos = async (token: string, ref: string) => {
   try {
-    const response = await getAntdContent('/components', token, ref);   
+    const response = await getAntdContent('/components', token, ref);
     const { data } = response;
     if (Array.isArray(data)) {
       const componentDirInfos = data.filter(item => item.type === 'dir');
@@ -60,34 +101,25 @@ export const getComponentDirInfos = async (token: string, ref: string) => {
 
 
 export const fetchDoc = async (ref: string, token: string) => {
+
   let dirInfos = await getComponentDirInfos(token, ref);
-  const zhPromises = dirInfos
-    ?.map(dirInfo => getAntdContent(`${dirInfo.path}/${ANTD_GITHUB.ZH_DOC_NAME}`, token, ref));
-  const enPromises = dirInfos
-    ?.map(dirInfo => getAntdContent(`${dirInfo.path}/${ANTD_GITHUB.EN_DOC_NAME}`, token, ref));
-  try {
-    const res = await Promise.allSettled([...zhPromises!, ...enPromises!]);
-    let docsMap: DocsMap = {};
-    // res.filter((item) => item.status !== 'fulfilled').forEach(item => {
-    //   console.log('fail: ', item);
-    // });
+  const componentNames = dirInfos?.map(dirInfo => dirInfo.name).filter(name => !excludeDirs.includes(name));
+  const componentDocsText = await getComponentsDocText(componentNames!, token, ref);
 
-    res.filter((item) => item.status === 'fulfilled')
-      .forEach((item: any) => {
-        const { path, encoding, content, name } = item.value.data;
-        const parsedContent = Buffer.from(content, encoding).toString();
-        const componentName = path.split('/')[1];
-        const lang = name.split('.')[1] as DocsLang;
-        if (!docsMap[componentName]) {
-          docsMap[componentName] = {};
-        }
-        docsMap[componentName][lang] = parsedContent;
-      });
-    console.log(docsMap);
-
-    return docsMap;
-  } catch (e) {
-    console.log(e);
-
+  let docsMap: DocsMap = {};
+  for (let key in componentDocsText) {
+    const componentName = recoverText(key.slice(0, key.length - 2));
+    
+    const lang = key.slice(key.length - 2) === 'zh' ? DocsLang.ZH : DocsLang.EN;
+    const text = componentDocsText[key]?.text;
+    if (!docsMap[componentName]) {
+      docsMap[componentName] = {};
+    }
+    docsMap[componentName][lang] = text;
   }
+
+  console.log('======= docsMap ========');
+  console.log(docsMap);
+
+  return docsMap;
 };

--- a/src/fetchDocs_old.ts
+++ b/src/fetchDocs_old.ts
@@ -1,0 +1,93 @@
+import { Octokit } from '@octokit/rest';
+import { ANTD_GITHUB, excludeDirs } from './constant';
+import { DocsLang, DocsMap } from './types';
+import * as vscode from 'vscode';
+
+const getAntdContent = (path: string, token: string, ref?: string) => new Octokit({ auth: token }).rest.repos.getContent({
+  owner: ANTD_GITHUB.OWNER,
+  repo: ANTD_GITHUB.REPO,
+  path,
+  ref,
+  headers: {
+    'X-GitHub-Api-Version': '2022-11-28'
+  }
+});
+
+export const getFileContent = async (owner: string, repo: string, path: string, token: string) => {
+  try {
+    const response = await new Octokit({ auth: token }).rest.repos.getContent({
+      owner: owner,
+      repo: repo,
+      path: path,
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+    return response.data;
+  } catch (error) {
+    console.error("Error retrieving file content:", error);
+  }
+};
+
+export const getComponentDirInfos = async (token: string, ref: string) => {
+  try {
+    const response = await getAntdContent('/components', token, ref);   
+    const { data } = response;
+    if (Array.isArray(data)) {
+      const componentDirInfos = data.filter(item => item.type === 'dir');
+      return componentDirInfos;
+    }
+  } catch (e: any) {
+    console.error('retrieving component dirs failed: ', e);
+    if (e.status === 401) {
+      console.log('github token invalid');
+      vscode.window.showErrorMessage(
+        "Github token is invalid, please set it correctly and reload this extension.",
+        "Set gitHub token"
+      )
+        .then((action) => {
+          if (action === "Set gitHub token") {
+            vscode.commands.executeCommand("workbench.action.openSettings", "Antd Docs");
+          }
+        });
+    } else {
+      vscode.window.showErrorMessage(e.response.data.message);
+    }
+    return [];
+  }
+};
+
+
+
+export const fetchDoc = async (ref: string, token: string) => {
+  let dirInfos = await getComponentDirInfos(token, ref);
+  const zhPromises = dirInfos
+    ?.map(dirInfo => getAntdContent(`${dirInfo.path}/${ANTD_GITHUB.ZH_DOC_NAME}`, token, ref));
+  const enPromises = dirInfos
+    ?.map(dirInfo => getAntdContent(`${dirInfo.path}/${ANTD_GITHUB.EN_DOC_NAME}`, token, ref));
+  try {
+    const res = await Promise.allSettled([...zhPromises!, ...enPromises!]);
+    let docsMap: DocsMap = {};
+    // res.filter((item) => item.status !== 'fulfilled').forEach(item => {
+    //   console.log('fail: ', item);
+    // });
+
+    res.filter((item) => item.status === 'fulfilled')
+      .forEach((item: any) => {
+        const { path, encoding, content, name } = item.value.data;
+        const parsedContent = Buffer.from(content, encoding).toString();
+        const componentName = path.split('/')[1];
+        const lang = name.split('.')[1] as DocsLang;
+        if (!docsMap[componentName]) {
+          docsMap[componentName] = {};
+        }
+        docsMap[componentName][lang] = parsedContent;
+      });
+    console.log(docsMap);
+
+    return docsMap;
+  } catch (e) {
+    console.log(e);
+
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,6 +253,14 @@
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/endpoint@^9.0.0":
+  version "9.0.4"
+  resolved "https://registry.npmmirror.com/@octokit/endpoint/-/endpoint-9.0.4.tgz#8afda5ad1ffc3073d08f2b450964c610b821d1ea"
+  integrity sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==
+  dependencies:
+    "@octokit/types" "^12.0.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/graphql@^5.0.0":
   version "5.0.6"
   resolved "https://registry.npmmirror.com/@octokit/graphql/-/graphql-5.0.6.tgz#9eac411ac4353ccc5d3fca7d76736e6888c5d248"
@@ -262,10 +270,24 @@
     "@octokit/types" "^9.0.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/graphql@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.npmmirror.com/@octokit/graphql/-/graphql-7.0.2.tgz#3df14b9968192f9060d94ed9e3aa9780a76e7f99"
+  integrity sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==
+  dependencies:
+    "@octokit/request" "^8.0.1"
+    "@octokit/types" "^12.0.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/openapi-types@^18.0.0":
   version "18.0.0"
   resolved "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-18.0.0.tgz#f43d765b3c7533fd6fb88f3f25df079c24fccf69"
   integrity sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==
+
+"@octokit/openapi-types@^19.1.0":
+  version "19.1.0"
+  resolved "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-19.1.0.tgz#75ec7e64743870fc73e1ab4bc6ec252ecdd624dc"
+  integrity sha512-6G+ywGClliGQwRsjvqVYpklIfa7oRPA0vyhPQG/1Feh+B+wU0vGH1JiJ5T25d3g1JZYBHzR2qefLi9x8Gt+cpw==
 
 "@octokit/plugin-paginate-rest@^6.1.2":
   version "6.1.2"
@@ -296,6 +318,15 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
+"@octokit/request-error@^5.0.0":
+  version "5.0.1"
+  resolved "https://registry.npmmirror.com/@octokit/request-error/-/request-error-5.0.1.tgz#277e3ce3b540b41525e07ba24c5ef5e868a72db9"
+  integrity sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==
+  dependencies:
+    "@octokit/types" "^12.0.0"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
 "@octokit/request@^6.0.0":
   version "6.2.8"
   resolved "https://registry.npmmirror.com/@octokit/request/-/request-6.2.8.tgz#aaf480b32ab2b210e9dadd8271d187c93171d8eb"
@@ -306,6 +337,16 @@
     "@octokit/types" "^9.0.0"
     is-plain-object "^5.0.0"
     node-fetch "^2.6.7"
+    universal-user-agent "^6.0.0"
+
+"@octokit/request@^8.0.1":
+  version "8.1.6"
+  resolved "https://registry.npmmirror.com/@octokit/request/-/request-8.1.6.tgz#a76a859c30421737a3918b40973c2ff369009571"
+  integrity sha512-YhPaGml3ncZC1NfXpP3WZ7iliL1ap6tLkAp6MvbK2fTTPytzVUyUesBBogcdMm86uRYO5rHaM1xIWxigWZ17MQ==
+  dependencies:
+    "@octokit/endpoint" "^9.0.0"
+    "@octokit/request-error" "^5.0.0"
+    "@octokit/types" "^12.0.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^19.0.11":
@@ -329,6 +370,13 @@
   integrity sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
+
+"@octokit/types@^12.0.0":
+  version "12.4.0"
+  resolved "https://registry.npmmirror.com/@octokit/types/-/types-12.4.0.tgz#8f97b601e91ce6b9776ed8152217e77a71be7aac"
+  integrity sha512-FLWs/AvZllw/AGVs+nJ+ELCDZZJk+kY0zMen118xhL2zD0s1etIUHm1odgjP7epxYU1ln7SZxEUWYop5bhsdgQ==
+  dependencies:
+    "@octokit/openapi-types" "^19.1.0"
 
 "@octokit/types@^9.0.0", "@octokit/types@^9.2.3":
   version "9.3.2"


### PR DESCRIPTION
Loop call to fetch all components' docs will call github rest api for many times(100+ times) in a fetching action. Some calls may be failed but the plugin considers it successful because most of calls are successful. GQL can get all docs in one api call and sovle the problem above.